### PR TITLE
Allow for non-default OPAMROOT locations

### DIFF
--- a/configure
+++ b/configure
@@ -504,12 +504,11 @@ def create_ninja_and_rc(l_installed):
         ''
     ]
 
-    if os.getenv('OPAMROOT'):
-        opam_root = os.getenv('OPAMROOT')
-        l_rc.append('export OPAMROOT={0}'.format(opam_root))
-        l_rc.append('source ${OPAMROOT}/opam-init/init.sh > /dev/null 2> /dev/null || true')
-    else:
-        l_rc.append('source ${HOME}/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true')
+    qp_opam_root = os.getenv('OPAMROOT')
+    if not qp_opam_root:
+        qp_opam_root = '${HOME}'
+    l_rc.append('export QP_OPAM={0}'.format(qp_opam_root))
+    l_rc.append('source ${QP_OPAM}/opam-init/init.sh > /dev/null 2> /dev/null || true')
     l_rc.append('')
 
     path = join(QP_ROOT, "quantum_package.rc")

--- a/configure
+++ b/configure
@@ -506,7 +506,7 @@ def create_ninja_and_rc(l_installed):
 
     qp_opam_root = os.getenv('OPAMROOT')
     if not qp_opam_root:
-        qp_opam_root = '${HOME}'
+        qp_opam_root = '${HOME}/.opam'
     l_rc.append('export QP_OPAM={0}'.format(qp_opam_root))
     l_rc.append('source ${QP_OPAM}/opam-init/init.sh > /dev/null 2> /dev/null || true')
     l_rc.append('')

--- a/configure
+++ b/configure
@@ -496,14 +496,21 @@ def create_ninja_and_rc(l_installed):
         'export LIBRARY_PATH="${QP_ROOT}"/lib:"${LIBRARY_PATH}"',
         'export C_INCLUDE_PATH="${C_INCLUDE_PATH}":"${QP_ROOT}"/include',
         '',
-        'source ${QP_ROOT}/install/EZFIO/Bash/ezfio.sh', "",
-        'source ${HOME}/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true',
+        'source ${QP_ROOT}/install/EZFIO/Bash/ezfio.sh',
         '',
         '# Choose the correct network interface',
         '# export QP_NIC=ib0',
         '# export QP_NIC=eth0',
-        ""
+        ''
     ]
+
+    if os.getenv('OPAMROOT'):
+        opam_root = os.getenv('OPAMROOT')
+        l_rc.append('export OPAMROOT={0}'.format(opam_root))
+        l_rc.append('source ${OPAMROOT}/opam-init/init.sh > /dev/null 2> /dev/null || true')
+    else:
+        l_rc.append('source ${HOME}/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true')
+    l_rc.append('')
 
     path = join(QP_ROOT, "quantum_package.rc")
     with open(path, "w+") as f:


### PR DESCRIPTION
Minor update to configure file to allow for non-default OPAMROOT directories. Helpful when you want to install this package for multiple users.