### PR TITLE
Fix: Pass user lib (the one in conf.cfg) to IRP.f90

### DIFF
--- a/scripts/compilation/qp_create_ninja.py
+++ b/scripts/compilation/qp_create_ninja.py
@@ -97,7 +97,9 @@ def ninja_create_env_variable(pwd_config_file):
         l_string.append(str_)
 
     lib_lapack = get_compilation_option(pwd_config_file, "LAPACK_LIB")
-    str_lib = " ".join([LIB, lib_lapack, EZFIO_LIB, ZMQ_LIB])
+    lib_usr = get_compilation_option(pwd_config_file, "LIB")
+
+    str_lib = " ".join([LIB, lib_lapack, EZFIO_LIB, ZMQ_LIB, lib_usr])
     l_string.append("LIB = {0} ".format(str_lib))
 
     l_string.append("")


### PR DESCRIPTION
LIB in config.cfg should be passed to IRP.f90.
It was not the case, this leads to some horrible debugging nightmare. And it was the fault of the me of 5 years ago  =*( 